### PR TITLE
Modificacion de la Query para "What is your USB ID?"

### DIFF
--- a/__tests__/utils/QueryProcessor.test.ts
+++ b/__tests__/utils/QueryProcessor.test.ts
@@ -23,7 +23,7 @@ describe("QueryProcessor", () => {
         const query = "what's your USB ID?";
         const response: string = QueryProcessor(query);
         expect(response).toBe((
-		"YOUR USB ID SHOULD BE HERE"
+		"TU USB ID: 17-10303"
     	));
     });
 });

--- a/utils/QueryProcessor.tsx
+++ b/utils/QueryProcessor.tsx
@@ -10,7 +10,7 @@ export default function QueryProcessor(query: string): string {
   if (query.toLowerCase().includes("usb id")) {
     // TODO añade tu USB ID a continuación
     // TODO actualiza el caso de prueba correspondiente en __tests__
-    return ( "TU USB ID DEBERÍA ESTAR AQUÍ" );
+    return ( "TU USB ID: 17-10303" );
   }
   return "";
 }


### PR DESCRIPTION
# Descripción
Se tiene como propósito arreglar el Query `what's your USB ID?` incorporando la respuesta esperada al mismo.

# Pruebas
Se tiene la prueba en local donde se tienen el pass de las todas las pruebas esperadas.
![imagen](https://github.com/user-attachments/assets/aef465c0-1be7-4ccb-9e2f-acf6ba3ffe76)
